### PR TITLE
Table and CustomTabsContainerV3: New Design Adjustments

### DIFF
--- a/.changeset/gentle-papayas-study.md
+++ b/.changeset/gentle-papayas-study.md
@@ -1,0 +1,5 @@
+---
+"@defactor/ui-kit": patch
+---
+
+Table and CustomTabsContainerV3: New Design Adjustments.

--- a/src/components/V3/CustomTabsContainerV3/index.tsx
+++ b/src/components/V3/CustomTabsContainerV3/index.tsx
@@ -74,6 +74,7 @@ export const CustomTabsContainerV3: React.FC<CustomTabsContainerProps> = ({
                 sx={{
                   ...defaultTabSx,
                   ...tabSx,
+                  flex: { xs: 1, md: "initial" },
                   fontWeight: value === tab.value ? 700 : 500,
                   color:
                     value === tab.value

--- a/src/components/V3/CustomTabsContainerV3/index.tsx
+++ b/src/components/V3/CustomTabsContainerV3/index.tsx
@@ -52,10 +52,10 @@ export const CustomTabsContainerV3: React.FC<CustomTabsContainerProps> = ({
       <TabContext value={value}>
         <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
           <TabList
+            scrollButtons={false}
             onChange={onChange}
             aria-label="custom tabs"
             variant="scrollable"
-            scrollButtons="auto"
             textColor="inherit"
             sx={{ minHeight: "unset" }}
             TabIndicatorProps={
@@ -77,6 +77,7 @@ export const CustomTabsContainerV3: React.FC<CustomTabsContainerProps> = ({
                   color: value === tab.value ? textActive : textDisabled,
                   ...defaultTabSx,
                   ...tabSx,
+                  minWidth: "120px"
                 }}
               />
             ))}

--- a/src/components/V3/CustomTabsContainerV3/index.tsx
+++ b/src/components/V3/CustomTabsContainerV3/index.tsx
@@ -24,7 +24,7 @@ export interface CustomTabsContainerProps {
 }
 
 export const defaultTabSx: SxProps<Theme> = {
-  padding: 1,
+  padding: 2,
   minWidth: 30,
   minHeight: 0,
   fontWeight: 700,
@@ -57,6 +57,7 @@ export const CustomTabsContainerV3: React.FC<CustomTabsContainerProps> = ({
             variant="scrollable"
             scrollButtons="auto"
             textColor="inherit"
+            sx={{ minHeight: "unset" }}
             TabIndicatorProps={
               tabIndicatorProps || {
                 sx: { backgroundColor: theme.palette.primary.main },

--- a/src/components/V3/CustomTabsContainerV3/index.tsx
+++ b/src/components/V3/CustomTabsContainerV3/index.tsx
@@ -42,8 +42,8 @@ export const CustomTabsContainerV3: React.FC<CustomTabsContainerProps> = ({
   tabIndicatorProps,
   px = 0,
   width = "100%",
-  textActive = '#000000',
-  textDisabled = '#797A7A'
+  textActive = "#000000",
+  textDisabled = "#797A7A",
 }) => {
   const theme = useTheme();
 
@@ -72,14 +72,11 @@ export const CustomTabsContainerV3: React.FC<CustomTabsContainerProps> = ({
                 icon={tab.icon || undefined}
                 iconPosition="start"
                 sx={{
-                  ...defaultTabSx,
-                  ...tabSx,
                   flex: { xs: 1, md: "initial" },
                   fontWeight: value === tab.value ? 700 : 500,
-                  color:
-                    value === tab.value
-                      ? textActive
-                      : textDisabled,
+                  color: value === tab.value ? textActive : textDisabled,
+                  ...defaultTabSx,
+                  ...tabSx,
                 }}
               />
             ))}

--- a/src/components/V3/CustomTabsContainerV3/index.tsx
+++ b/src/components/V3/CustomTabsContainerV3/index.tsx
@@ -73,6 +73,7 @@ export const CustomTabsContainerV3: React.FC<CustomTabsContainerProps> = ({
                 sx={{
                   ...defaultTabSx,
                   ...tabSx,
+                  fontWeight: value === tab.value ? 700 : 500,
                   color:
                     value === tab.value
                       ? textActive

--- a/src/scss/components/Table/_table.scss
+++ b/src/scss/components/Table/_table.scss
@@ -138,7 +138,7 @@ tr {
   padding: 8px 24px;
   display: flex;
   height: 64px;
-  @media (max-width: '300px') {
+  @media (max-width: '400px') {
     flex-direction: column-reverse;
     justify-content: center;
     padding: 8px;

--- a/src/stories/CustomTabsContainerV3.stories.tsx
+++ b/src/stories/CustomTabsContainerV3.stories.tsx
@@ -35,7 +35,7 @@ const Template: StoryFn<StoryProps> = ({
   };
 
   return (
-    <Box sx={{ width: containerWidth, border: '1px solid #1EA7FD'}}>
+    <Box sx={{ width: containerWidth, border: "1px solid #1EA7FD" }}>
       <CustomTabsContainerV3 {...args} value={value} onChange={handleChange} />
     </Box>
   );
@@ -46,7 +46,7 @@ const tabItems: TabItem[] = [
     value: "1",
     label: "Positions",
     icon: (
-      <Box mr={1}>
+      <Box mr={1} sx={{ display: "flex", alignItems: "center" }}>
         <Coins01 width="20px" height="20px" color="#5a5beb" />
       </Box>
     ),
@@ -60,8 +60,8 @@ const tabItems: TabItem[] = [
     value: "2",
     label: "Archive",
     icon: (
-      <Box mr={1}>
-        <Trash04 width="20px" height="20px"/>
+      <Box mr={1} sx={{ display: "flex", alignItems: "center" }}>
+        <Trash04 width="20px" height="20px" />
       </Box>
     ),
     tabsContent: (
@@ -82,5 +82,5 @@ export const MobileTabs = Template.bind({});
 MobileTabs.args = {
   items: tabItems,
   containerWidth: "400px",
-  tabSx: customTabSx
+  tabSx: customTabSx,
 };

--- a/src/stories/CustomTabsContainerV3.stories.tsx
+++ b/src/stories/CustomTabsContainerV3.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Meta, StoryFn } from "@storybook/react";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, SxProps, Theme } from "@mui/material";
 import {
   CustomTabsContainerV3,
   CustomTabsContainerProps,
@@ -8,12 +8,26 @@ import {
 } from "../components/V3/CustomTabsContainerV3";
 import { Trash04, Coins01 } from "@untitled-ui/icons-react";
 
+const customTabSx: SxProps<Theme> = {
+  fontSize: "14px",
+  pr: 1,
+  pl: 1,
+};
+
+interface StoryProps extends CustomTabsContainerProps {
+  containerWidth?: string;
+  tabSx?: SxProps<Theme>;
+}
+
 export default {
   title: "V3/CustomTabsContainerV3",
   component: CustomTabsContainerV3,
 } as Meta<CustomTabsContainerProps>;
 
-const Template: StoryFn<CustomTabsContainerProps> = (args) => {
+const Template: StoryFn<StoryProps> = ({
+  containerWidth = "100%",
+  ...args
+}) => {
   const [value, setValue] = useState("1");
 
   const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
@@ -21,7 +35,7 @@ const Template: StoryFn<CustomTabsContainerProps> = (args) => {
   };
 
   return (
-    <Box sx={{ width: "100%" }}>
+    <Box sx={{ width: containerWidth }}>
       <CustomTabsContainerV3 {...args} value={value} onChange={handleChange} />
     </Box>
   );
@@ -33,9 +47,7 @@ const tabItems: TabItem[] = [
     label: "Positions",
     icon: (
       <Box mr={1}>
-           <Box mr={1}>
-        <Coins01 color='#5a5beb' />
-      </Box>
+        <Coins01 color="#5a5beb" />
       </Box>
     ),
     tabsContent: (
@@ -63,4 +75,12 @@ const tabItems: TabItem[] = [
 export const DefaultTabs = Template.bind({});
 DefaultTabs.args = {
   items: tabItems,
+  containerWidth: "100%",
+};
+
+export const MobileTabs = Template.bind({});
+MobileTabs.args = {
+  items: tabItems,
+  containerWidth: "400px",
+  tabSx: customTabSx,
 };

--- a/src/stories/CustomTabsContainerV3.stories.tsx
+++ b/src/stories/CustomTabsContainerV3.stories.tsx
@@ -12,6 +12,7 @@ const customTabSx: SxProps<Theme> = {
   fontSize: "14px",
   pr: 1,
   pl: 1,
+  flex: 1,
 };
 
 interface StoryProps extends CustomTabsContainerProps {

--- a/src/stories/CustomTabsContainerV3.stories.tsx
+++ b/src/stories/CustomTabsContainerV3.stories.tsx
@@ -47,7 +47,7 @@ const tabItems: TabItem[] = [
     label: "Positions",
     icon: (
       <Box mr={1}>
-        <Coins01 color="#5a5beb" />
+        <Coins01 width="20px" height="20px" color="#5a5beb" />
       </Box>
     ),
     tabsContent: (
@@ -61,7 +61,7 @@ const tabItems: TabItem[] = [
     label: "Archive",
     icon: (
       <Box mr={1}>
-        <Trash04 />
+        <Trash04 width="20px" height="20px"/>
       </Box>
     ),
     tabsContent: (

--- a/src/stories/CustomTabsContainerV3.stories.tsx
+++ b/src/stories/CustomTabsContainerV3.stories.tsx
@@ -71,6 +71,34 @@ const tabItems: TabItem[] = [
       </Typography>
     ),
   },
+  {
+    value: "3",
+    label: "Archive",
+    icon: (
+      <Box mr={1} sx={{ display: "flex", alignItems: "center" }}>
+        <Trash04 width="20px" height="20px" />
+      </Box>
+    ),
+    tabsContent: (
+      <Typography p={2}>
+        This is the <strong>Archive</strong> tab content.
+      </Typography>
+    ),
+  },
+  {
+    value: "4",
+    label: "Archive",
+    icon: (
+      <Box mr={1} sx={{ display: "flex", alignItems: "center" }}>
+        <Trash04 width="20px" height="20px" />
+      </Box>
+    ),
+    tabsContent: (
+      <Typography p={2}>
+        This is the <strong>Archive</strong> tab content.
+      </Typography>
+    ),
+  },
 ];
 
 export const DefaultTabs = Template.bind({});

--- a/src/stories/CustomTabsContainerV3.stories.tsx
+++ b/src/stories/CustomTabsContainerV3.stories.tsx
@@ -33,7 +33,9 @@ const tabItems: TabItem[] = [
     label: "Positions",
     icon: (
       <Box mr={1}>
-        <Coins01 />
+           <Box mr={1}>
+        <Coins01 color='#5a5beb' />
+      </Box>
       </Box>
     ),
     tabsContent: (

--- a/src/stories/CustomTabsContainerV3.stories.tsx
+++ b/src/stories/CustomTabsContainerV3.stories.tsx
@@ -70,35 +70,7 @@ const tabItems: TabItem[] = [
         This is the <strong>Archive</strong> tab content.
       </Typography>
     ),
-  },
-  {
-    value: "3",
-    label: "Archive",
-    icon: (
-      <Box mr={1} sx={{ display: "flex", alignItems: "center" }}>
-        <Trash04 width="20px" height="20px" />
-      </Box>
-    ),
-    tabsContent: (
-      <Typography p={2}>
-        This is the <strong>Archive</strong> tab content.
-      </Typography>
-    ),
-  },
-  {
-    value: "4",
-    label: "Archive",
-    icon: (
-      <Box mr={1} sx={{ display: "flex", alignItems: "center" }}>
-        <Trash04 width="20px" height="20px" />
-      </Box>
-    ),
-    tabsContent: (
-      <Typography p={2}>
-        This is the <strong>Archive</strong> tab content.
-      </Typography>
-    ),
-  },
+  }
 ];
 
 export const DefaultTabs = Template.bind({});

--- a/src/stories/CustomTabsContainerV3.stories.tsx
+++ b/src/stories/CustomTabsContainerV3.stories.tsx
@@ -35,7 +35,7 @@ const Template: StoryFn<StoryProps> = ({
   };
 
   return (
-    <Box sx={{ width: containerWidth }}>
+    <Box sx={{ width: containerWidth, border: '1px solid #1EA7FD'}}>
       <CustomTabsContainerV3 {...args} value={value} onChange={handleChange} />
     </Box>
   );
@@ -82,5 +82,5 @@ export const MobileTabs = Template.bind({});
 MobileTabs.args = {
   items: tabItems,
   containerWidth: "400px",
-  tabSx: customTabSx,
+  tabSx: customTabSx
 };


### PR DESCRIPTION
## Table and CustomTabsContainerV3: New Design Adjustments

- [x] Adjusted font weight:

CustomTabsContainerV3: Use non-bold font for unselected tabs. 
![Image](https://github.com/user-attachments/assets/c133953b-1e9c-400d-b1d9-3823ee6c652e)

- [x] Add mobile demo to storybook file

- [x]  ...and aligned tab positions for mobile responsiveness


from:

![Image](https://github.com/user-attachments/assets/7410f4fd-99b5-4d6c-a95b-d7778c4b981c)

to: 

![Image](https://github.com/user-attachments/assets/d8ad217e-45bc-43ec-af9c-b35b8f5a1087)

- [x] Color icons in storybook file


- [x]  Table: 


change 300px to 400px
.pagination-container {
...
https://github.com/media (max-width: '300px') {
flex-direction: column-reverse;
justify-content: center;
padding: 8px;
gap: 8px;
height: auto;
}
}

### What does this PR do?

- Resolve #608 
